### PR TITLE
Example fix: Set the type of the store

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,7 +22,7 @@ void main() {
 class FlutterReduxApp extends StatelessWidget {
   // Create your store as a final variable in a base Widget. This works better
   // with Hot Reload than creating it directly in the `build` function.
-  final store = new Store(counterReducer, initialState: 0);
+  final store = new Store<int>(counterReducer, initialState: 0);
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
Hey there,

I just watched your talk on the dart conference. Great job! I was eager to try out your library and went straight to the examples when I stumbled on this part of the code:

`final store = new Store(counterReducer, initialState: 0);`

I am not sure if this is because of the new Dart SDK `dart2.0.0-dev.16.0`, but the line is causing the following warning:

> [dart] A function of type '(int, Object) → int' can't be assigned to a variable of type '(dynamic, dynamic) → dynamic'.

I just went ahead and fixed the sample, it is a small contribution, but I think others that are new to the library will be less confused than I was.