### PR TITLE
Call onInit before the ViewModel is created.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.5
+
+  * Bugfix: `onInit` was not called before the initial ViewModel is constructed. 
+
 ## 0.3.4
 
   * Fix Changelog. 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,2 @@
+analyzer:
+  strong-mode: true

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -7,7 +7,7 @@ enum Actions { Increment }
 
 // The reducer, which takes the previous count and increments it in response
 // to an Increment action.
-int counterReducer(int state, action) {
+int counterReducer(int state, dynamic action) {
   if (action == Actions.Increment) {
     return state + 1;
   }
@@ -16,14 +16,23 @@ int counterReducer(int state, action) {
 }
 
 void main() {
-  runApp(new FlutterReduxApp());
-}
-
-class FlutterReduxApp extends StatelessWidget {
   // Create your store as a final variable in a base Widget. This works better
   // with Hot Reload than creating it directly in the `build` function.
   final store = new Store<int>(counterReducer, initialState: 0);
 
+  runApp(new FlutterReduxApp(store: store));
+}
+
+class FlutterReduxApp extends StatefulWidget {
+  final Store<int> store;
+
+  FlutterReduxApp({Key key, this.store}) : super(key: key);
+
+  @override
+  _FlutterReduxAppState createState() => new _FlutterReduxAppState();
+}
+
+class _FlutterReduxAppState extends State<FlutterReduxApp> {
   @override
   Widget build(BuildContext context) {
     final title = 'Flutter Redux Demo';
@@ -34,7 +43,7 @@ class FlutterReduxApp extends StatelessWidget {
       home: new StoreProvider(
         // Pass the store to the StoreProvider. Any ancestor `StoreConnector`
         // Widgets will find and use this value as the `Store`.
-        store: store,
+        store: widget.store,
         child: new Scaffold(
           appBar: new AppBar(
             title: new Text(title),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,7 +7,8 @@ dependencies:
 
 dev_dependencies:
   redux: ">=2.0.0 <3.0.0"
-  flutter_redux: ">=0.3.0 <0.4.0"
+  flutter_redux:
+    path: ../
   flutter_test:
     sdk: flutter
 

--- a/lib/flutter_redux.dart
+++ b/lib/flutter_redux.dart
@@ -228,7 +228,7 @@ class _StoreStreamListener<S, ViewModel> extends StatefulWidget {
   final bool distinct;
   final OnInitCallback onInit;
   final OnDisposeCallback onDispose;
-  final IgnoreChangeTest ignoreChange;
+  final IgnoreChangeTest<S> ignoreChange;
 
   _StoreStreamListener({
     Key key,
@@ -255,7 +255,12 @@ class _StoreStreamListenerState<ViewModel> extends State<_StoreStreamListener> {
 
   @override
   void initState() {
+    if (widget.onInit != null) {
+      widget.onInit(widget.store);
+    }
+
     _init();
+
     super.initState();
   }
 
@@ -306,10 +311,6 @@ class _StoreStreamListenerState<ViewModel> extends State<_StoreStreamListener> {
       latestValue = vm;
       sink.add(vm);
     }));
-
-    if (widget.onInit != null) {
-      widget.onInit(widget.store);
-    }
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_redux
 description: A library that connects Widgets to a Redux Store
-version: 0.3.4
+version: 0.3.5
 author: Brian Egan <brian@brianegan.com>
 homepage: https://github.com/brianegan/flutter_redux
 

--- a/test/flutter_redux_test.dart
+++ b/test/flutter_redux_test.dart
@@ -8,10 +8,9 @@ void main() {
   group('StoreProvider', () {
     testWidgets('passes a Redux Store down to its ancestors',
         (WidgetTester tester) async {
-      final defaultState = "test";
       final store = new Store(
         new IdentityReducer(),
-        initialState: defaultState,
+        initialState: "I",
       );
       final widget = new StoreProvider(
         store: store,
@@ -27,8 +26,6 @@ void main() {
 
     testWidgets('should update the children if the store changes',
         (WidgetTester tester) async {
-      final defaultState = "test";
-      final newState = "new";
       Widget widget([String state]) {
         return new StoreProvider(
           store: new Store(
@@ -39,21 +36,20 @@ void main() {
         );
       }
 
-      await tester.pumpWidget(widget(defaultState));
-      await tester.pumpWidget(widget(newState));
+      await tester.pumpWidget(widget("I"));
+      await tester.pumpWidget(widget("A"));
 
       StoreCaptor captor = tester.firstWidget(find.byType(StoreCaptor));
 
-      expect(captor.store.state, newState);
+      expect(captor.store.state, "A");
     });
   });
 
   group('StoreConnector', () {
     testWidgets('initially builds from the current state of the store',
         (WidgetTester tester) async {
-      final initial = "initial";
       final widget = new StoreProvider(
-        store: new Store(new IdentityReducer(), initialState: initial),
+        store: new Store(new IdentityReducer(), initialState: "I"),
         child: new StoreBuilder(
           builder: (context, store) => new Text(
                 store.state,
@@ -64,14 +60,13 @@ void main() {
 
       await tester.pumpWidget(widget);
 
-      expect(find.text(initial), findsOneWidget);
+      expect(find.text("I"), findsOneWidget);
     });
 
     testWidgets('can convert the store to a ViewModel',
         (WidgetTester tester) async {
-      final initial = "initial";
       final widget = new StoreProvider(
-        store: new Store(new IdentityReducer(), initialState: initial),
+        store: new Store(new IdentityReducer(), initialState: "I"),
         child: new StoreConnector(
           converter: (store) => store.state,
           builder: (context, latest) => new Text(
@@ -83,16 +78,14 @@ void main() {
 
       await tester.pumpWidget(widget);
 
-      expect(find.text(initial), findsOneWidget);
+      expect(find.text("I"), findsOneWidget);
     });
 
     testWidgets('builds the latest state of the store after a change event',
         (WidgetTester tester) async {
-      final initial = "initial";
-      final newState = "newState";
       final store = new Store(
         new IdentityReducer(),
-        initialState: initial,
+        initialState: "I",
       );
       final widget = new StoreProvider(
         store: store,
@@ -110,21 +103,20 @@ void main() {
       await tester.pumpWidget(widget);
 
       // Dispatch a new action
-      store.dispatch(newState);
+      store.dispatch("A");
 
       // Build the widget again with the new state
       await tester.pumpWidget(widget);
 
-      expect(find.text(newState), findsOneWidget);
+      expect(find.text("A"), findsOneWidget);
     });
 
     testWidgets('rebuilds by default whenever the store emits a change',
         (WidgetTester tester) async {
       var numBuilds = 0;
-      final initial = "initial";
       final store = new Store(
         new IdentityReducer(),
-        initialState: initial,
+        initialState: "I",
       );
       final widget = new StoreProvider(
         store: store,
@@ -144,7 +136,7 @@ void main() {
       expect(numBuilds, 1);
 
       // Dispatch the exact same event. This should still trigger a rebuild
-      store.dispatch(initial);
+      store.dispatch("I");
 
       await tester.pumpWidget(widget);
 
@@ -154,10 +146,9 @@ void main() {
     testWidgets('does not rebuild if rebuildOnChange is set to false',
         (WidgetTester tester) async {
       var numBuilds = 0;
-      final initial = "initial";
       final store = new Store(
         new IdentityReducer(),
-        initialState: initial,
+        initialState: "I",
       );
       final widget = new StoreProvider(
         store: store,
@@ -182,7 +173,7 @@ void main() {
       // false.
       //
       // By default, this should still trigger a rebuild
-      store.dispatch(initial);
+      store.dispatch("I");
 
       await tester.pumpWidget(widget);
 
@@ -192,10 +183,9 @@ void main() {
     testWidgets('does not rebuild if ignoreChange returns true',
         (WidgetTester tester) async {
       var numBuilds = 0;
-      final initial = "initial";
       final store = new Store(
         new IdentityReducer(),
-        initialState: initial,
+        initialState: "I",
       );
       final widget = new StoreProvider(
         store: store,
@@ -225,98 +215,18 @@ void main() {
       expect(numBuilds, 1);
     });
 
-    testWidgets('StoreBuilder also runs a function when initialized',
+    testWidgets('optionally runs a function when initialized',
         (WidgetTester tester) async {
       var numBuilds = 0;
-      final action = "action";
-      final onInit = new StoreCounter();
+      final counter = new CallCounter();
       final store = new Store(
         new IdentityReducer(),
-        initialState: action,
-      );
-      final widget = () => new StoreProvider(
-            store: store,
-            child: new StoreBuilder(
-              onInit: onInit,
-              builder: (context, store) {
-                numBuilds++;
-
-                return new Container();
-              },
-            ),
-          );
-
-      // Build the widget with the initial state
-      await tester.pumpWidget(widget());
-
-      // Expect the Widget to be rebuilt and the onInit method to be called
-      expect(onInit.callCount, 1);
-      expect(numBuilds, 1);
-
-      store.dispatch(action);
-
-      // Rebuild the widget
-      await tester.pumpWidget(widget());
-
-      // Expect the Widget to be rebuilt, but the onInit method should NOT be
-      // called a second time.
-      expect(numBuilds, 2);
-      expect(onInit.callCount, 1);
-
-      store.dispatch("just to be sure");
-
-      // Rebuild the widget
-      await tester.pumpWidget(widget());
-
-      // Expect the Widget to be rebuilt, but the onInit method should NOT be
-      // called a third time.
-      expect(numBuilds, 3);
-      expect(onInit.callCount, 1);
-    });
-
-    testWidgets('StoreBuilder also runs a function when disposed',
-        (WidgetTester tester) async {
-      final action = "action";
-      final onDispose = new StoreCounter();
-      final store = new Store(
-        new IdentityReducer(),
-        initialState: action,
-      );
-      final widget = () => new StoreProvider(
-            store: store,
-            child: new StoreBuilder(
-              onDispose: onDispose,
-              builder: (context, store) => new Container(),
-            ),
-          );
-
-      // Build the widget with the initial state
-      await tester.pumpWidget(widget());
-
-      expect(onDispose.callCount, 0);
-
-      store.dispatch(action);
-
-      // Rebuild a different widget, should trigger a dispose as the
-      // StoreBuilder has been removed from the Widget tree.
-      await tester.pumpWidget(new Container());
-
-      expect(onDispose.callCount, 1);
-    });
-
-    testWidgets('optionally runs a function when the State is initialized',
-        (WidgetTester tester) async {
-      var numBuilds = 0;
-      final action = "action";
-      final onInit = new StoreCounter();
-      final store = new Store(
-        new IdentityReducer(),
-        initialState: action,
+        initialState: "A",
       );
       final widget = () => new StoreProvider(
             store: store,
             child: new StoreConnector(
-              onInit: onInit,
+              onInit: counter,
               converter: (store) => store.state,
               builder: (context, latest) {
                 numBuilds++;
@@ -330,10 +240,10 @@ void main() {
       await tester.pumpWidget(widget());
 
       // Expect the Widget to be rebuilt and the onInit method to be called
-      expect(onInit.callCount, 1);
+      expect(counter.callCount, 1);
       expect(numBuilds, 1);
 
-      store.dispatch(action);
+      store.dispatch("A");
 
       // Rebuild the widget
       await tester.pumpWidget(widget());
@@ -341,7 +251,7 @@ void main() {
       // Expect the Widget to be rebuilt, but the onInit method should NOT be
       // called a second time.
       expect(numBuilds, 2);
-      expect(onInit.callCount, 1);
+      expect(counter.callCount, 1);
 
       store.dispatch("just to be sure");
 
@@ -351,21 +261,50 @@ void main() {
       // Expect the Widget to be rebuilt, but the onInit method should NOT be
       // called a third time.
       expect(numBuilds, 3);
-      expect(onInit.callCount, 1);
+      expect(counter.callCount, 1);
     });
 
-    testWidgets('optionally runs a function when the State is disposed',
+    testWidgets('onInit is called before the first ViewModel is built',
         (WidgetTester tester) async {
-      final action = "action";
-      final onDispose = new StoreCounter();
+      var currentState;
       final store = new Store(
         new IdentityReducer(),
-        initialState: action,
+        initialState: "I",
+      );
+      final widget = () {
+        return new StoreProvider(
+          store: store,
+          child: new StoreConnector(
+            converter: (store) => store.state,
+            onInit: (store) {
+              store.dispatch("A");
+            },
+            builder: (context, state) {
+              currentState = state;
+              return new Container();
+            },
+          ),
+        );
+      };
+
+      // Build the widget with the initial state
+      await tester.pumpWidget(widget());
+
+      // Expect the Widget to be rebuilt and the onInit method to be called
+      expect(currentState, "A");
+    });
+
+    testWidgets('optionally runs a function when disposed',
+        (WidgetTester tester) async {
+      final counter = new CallCounter();
+      final store = new Store(
+        new IdentityReducer(),
+        initialState: "A",
       );
       final widget = () => new StoreProvider(
             store: store,
             child: new StoreConnector(
-              onDispose: onDispose,
+              onDispose: counter,
               converter: (store) => store.state,
               builder: (context, latest) => new Container(),
             ),
@@ -375,24 +314,100 @@ void main() {
       await tester.pumpWidget(widget());
 
       // onDispose should not be called yet.
-      expect(onDispose.callCount, 0);
+      expect(counter.callCount, 0);
 
-      store.dispatch(action);
+      store.dispatch("A");
 
       // Rebuild a different widget tree. Expect this to trigger `onDispose`.
       await tester.pumpWidget(new Container());
 
-      expect(onDispose.callCount, 1);
+      expect(counter.callCount, 1);
+    });
+
+    testWidgets('StoreBuilder also runs a function when initialized',
+        (WidgetTester tester) async {
+      var numBuilds = 0;
+      final counter = new CallCounter();
+      final store = new Store(
+        new IdentityReducer(),
+        initialState: "A",
+      );
+      final widget = () => new StoreProvider(
+            store: store,
+            child: new StoreBuilder(
+              onInit: counter,
+              builder: (context, store) {
+                numBuilds++;
+
+                return new Container();
+              },
+            ),
+          );
+
+      // Build the widget with the initial state
+      await tester.pumpWidget(widget());
+
+      // Expect the Widget to be rebuilt and the onInit method to be called
+      expect(counter.callCount, 1);
+      expect(numBuilds, 1);
+
+      store.dispatch("A");
+
+      // Rebuild the widget
+      await tester.pumpWidget(widget());
+
+      // Expect the Widget to be rebuilt, but the onInit method should NOT be
+      // called a second time.
+      expect(numBuilds, 2);
+      expect(counter.callCount, 1);
+
+      store.dispatch("just to be sure");
+
+      // Rebuild the widget
+      await tester.pumpWidget(widget());
+
+      // Expect the Widget to be rebuilt, but the onInit method should NOT be
+      // called a third time.
+      expect(numBuilds, 3);
+      expect(counter.callCount, 1);
+    });
+
+    testWidgets('StoreBuilder also runs a function when disposed',
+        (WidgetTester tester) async {
+      final counter = new CallCounter();
+      final store = new Store(
+        new IdentityReducer(),
+        initialState: "init",
+      );
+      final widget = () => new StoreProvider(
+            store: store,
+            child: new StoreBuilder(
+              onDispose: counter,
+              builder: (context, store) => new Container(),
+            ),
+          );
+
+      // Build the widget with the initial state
+      await tester.pumpWidget(widget());
+
+      expect(counter.callCount, 0);
+
+      store.dispatch("A");
+
+      // Rebuild a different widget, should trigger a dispose as the
+      // StoreBuilder has been removed from the Widget tree.
+      await tester.pumpWidget(new Container());
+
+      expect(counter.callCount, 1);
     });
 
     testWidgets(
         'avoids rebuilds when distinct is used with an object that implements ==',
         (WidgetTester tester) async {
       var numBuilds = 0;
-      final initial = "initial";
       final store = new Store(
         new IdentityReducer(),
-        initialState: initial,
+        initialState: "I",
       );
       final widget = new StoreProvider(
         store: store,
@@ -414,7 +429,7 @@ void main() {
       expect(numBuilds, 1);
 
       // Dispatch another action of the same type
-      store.dispatch(initial);
+      store.dispatch("I");
 
       await tester.pumpWidget(widget);
 
@@ -422,7 +437,7 @@ void main() {
 
       // Dispatch another action of a different type. This should trigger another
       // rebuild
-      store.dispatch("new");
+      store.dispatch("A");
 
       await tester.pumpWidget(widget);
 
@@ -452,7 +467,7 @@ class IdentityReducer extends ReducerClass {
   }
 }
 
-class StoreCounter {
+class CallCounter {
   final List<Store> stores = [];
 
   int get callCount => stores.length;


### PR DESCRIPTION
This allows users to dispatch sync actions within the onInit function.

Fixes #8