### PR TITLE
Update IgnoreChangeTest documentation

### DIFF
--- a/lib/flutter_redux.dart
+++ b/lib/flutter_redux.dart
@@ -78,7 +78,7 @@ typedef OnDisposeCallback<S> = void Function(
 /// it can be best to ignore the State change while your animation completes.
 ///
 /// To ignore a change, provide a function that returns true or false. If the
-/// returned value is false, the change will be ignored.
+/// returned value is true, the change will be ignored.
 ///
 /// If you ignore a change, and the framework needs to rebuild the Widget, the
 /// `builder` function will be called with the latest `ViewModel` produced by


### PR DESCRIPTION
My understanding of the `ignoreChange` code contradicts the provided dartdoc:

The doc states: 
```
/// To ignore a change, provide a function that returns true or false. If the
/// returned value is false, the change will be ignored.
```

But the code shows:

```
_stream = _stream.where((state) => !widget.ignoreChange(state));
```

Which means that changes are ignored if `ignoreChange` returns `true` [fitting with the naming].

This is a quick one-word PR that modifies the doc.