### PR TITLE
Handle Widget configuration changes & rebuilds

### DIFF
--- a/lib/flutter_redux.dart
+++ b/lib/flutter_redux.dart
@@ -393,7 +393,18 @@ class _StoreStreamListenerState<S, ViewModel>
 
   @override
   void initState() {
-    _init();
+    if (widget.onInit != null) {
+      widget.onInit(widget.store);
+    }
+
+    if (widget.onInitialBuild != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        widget.onInitialBuild(latestValue);
+      });
+    }
+
+    latestValue = widget.converter(widget.store);
+    _createStream();
 
     super.initState();
   }
@@ -409,63 +420,13 @@ class _StoreStreamListenerState<S, ViewModel>
 
   @override
   void didUpdateWidget(_StoreStreamListener<S, ViewModel> oldWidget) {
+    latestValue = widget.converter(widget.store);
+
     if (widget.store != oldWidget.store) {
-      _init();
+      _createStream();
     }
 
     super.didUpdateWidget(oldWidget);
-  }
-
-  void _init() {
-    if (widget.onInit != null) {
-      widget.onInit(widget.store);
-    }
-
-    latestValue = widget.converter(widget.store);
-
-    if (widget.onInitialBuild != null) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        widget.onInitialBuild(latestValue);
-      });
-    }
-
-    var _stream = widget.store.onChange;
-
-    if (widget.ignoreChange != null) {
-      _stream = _stream.where((state) => !widget.ignoreChange(state));
-    }
-
-    stream = _stream.map((_) => widget.converter(widget.store));
-
-    // Don't use `Stream.distinct` because it cannot capture the initial
-    // ViewModel produced by the `converter`.
-    if (widget.distinct) {
-      stream = stream.where((vm) {
-        final isDistinct = vm != latestValue;
-
-        return isDistinct;
-      });
-    }
-
-    // After each ViewModel is emitted from the Stream, we update the
-    // latestValue. Important: This must be done after all other optional
-    // transformations, such as ignoreChange.
-    stream =
-        stream.transform(StreamTransformer.fromHandlers(handleData: (vm, sink) {
-      latestValue = vm;
-
-      if (widget.onWillChange != null) {
-        widget.onWillChange(latestValue);
-      }
-
-      if (widget.onDidChange != null) {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          widget.onDidChange(latestValue);
-        });
-      }
-
-      sink.add(vm);
-    }));
   }
 
   @override
@@ -475,10 +436,59 @@ class _StoreStreamListenerState<S, ViewModel>
             stream: stream,
             builder: (context, snapshot) => widget.builder(
               context,
-              snapshot.hasData ? snapshot.data : latestValue,
+              latestValue,
             ),
           )
         : widget.builder(context, latestValue);
+  }
+
+  ViewModel _mapConverter(S state) {
+    return widget.converter(widget.store);
+  }
+
+  bool _whereDistinct(ViewModel vm) {
+    if (widget.distinct) {
+      return vm != latestValue;
+    }
+
+    return true;
+  }
+
+  bool _ignoreChange(S state) {
+    if (widget.ignoreChange != null) {
+      return !widget.ignoreChange(state);
+    }
+
+    return true;
+  }
+
+  void _createStream() {
+    stream = widget.store.onChange
+        .where(_ignoreChange)
+        .map(_mapConverter)
+        // Don't use `Stream.distinct` because it cannot capture the initial
+        // ViewModel produced by the `converter`.
+        .where(_whereDistinct)
+        // After each ViewModel is emitted from the Stream, we update the
+        // latestValue. Important: This must be done after all other optional
+        // transformations, such as ignoreChange.
+        .transform(StreamTransformer.fromHandlers(handleData: _handleChange));
+  }
+
+  void _handleChange(ViewModel vm, EventSink<ViewModel> sink) {
+    latestValue = vm;
+
+    if (widget.onWillChange != null) {
+      widget.onWillChange(latestValue);
+    }
+
+    if (widget.onDidChange != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        widget.onDidChange(latestValue);
+      });
+    }
+
+    sink.add(vm);
   }
 }
 

--- a/test/flutter_redux_test.dart
+++ b/test/flutter_redux_test.dart
@@ -42,7 +42,7 @@ void main() {
 
     testWidgets('should update the children if the store changes',
         (WidgetTester tester) async {
-      Widget widget([String state]) {
+      Widget widget(String state) {
         return StoreProvider<String>(
           store: Store<String>(
             identityReducer,
@@ -470,13 +470,138 @@ void main() {
 
       expect(numBuilds, 1);
 
-      // Dispatch another action of a different type. This should trigger another
-      // rebuild
+      // Dispatch another action of a different type. This should trigger
+      // another rebuild
       store.dispatch('A');
 
       await tester.pumpWidget(widget);
 
       expect(numBuilds, 2);
+    });
+
+    group('Updates', () {
+      testWidgets(
+        'converter update results in proper rebuild',
+        (WidgetTester tester) async {
+          String currentState;
+          final store = Store<String>(
+            identityReducer,
+            initialState: 'I',
+          );
+          Widget widget([StoreConverter<String, String> converter = selector]) {
+            return StoreProvider<String>(
+              store: store,
+              child: StoreConnector<String, String>(
+                converter: converter,
+                onInit: (store) => store.dispatch('A'),
+                builder: (context, vm) {
+                  currentState = vm;
+                  return Container();
+                },
+              ),
+            );
+          }
+
+          // Build the widget with the initial state
+          await tester.pumpWidget(widget());
+
+          // Expect the Widget to be rebuilt and the onInit method to be called
+          expect(currentState, 'A');
+
+          // Rebuild the widget with a new converter
+          await tester.pumpWidget(widget((Store<String> s) => 'B'));
+
+          // Expect the Widget to be rebuilt and the converter should be rerun
+          expect(currentState, 'B');
+        },
+      );
+
+      testWidgets(
+        'onDidChange works as expected',
+        (WidgetTester tester) async {
+          String currentState;
+          final store = Store<String>(
+            identityReducer,
+            initialState: 'I',
+          );
+          Widget widget([void Function(String viewModel) onDidChange]) {
+            return StoreProvider<String>(
+              store: store,
+              child: StoreConnector<String, String>(
+                converter: selector,
+                onDidChange: onDidChange,
+                onInit: (store) => store.dispatch('A'),
+                builder: (context, vm) {
+                  return Container();
+                },
+              ),
+            );
+          }
+
+          // Build the widget with the initial state
+          await tester.pumpWidget(widget());
+
+          // No onDidChange function to run, so currentState should be null
+          expect(currentState, isNull);
+
+          // Build the widget with a new onDidChange
+          final newWidget = widget((_) => currentState = 'S');
+          await tester.pumpWidget(newWidget);
+
+          // Dispatch a new value, which should cause onDidChange to run
+          store.dispatch('B');
+
+          // Run pumpWidget, which should flush the after build (didChange)
+          // callbacks
+          await tester.pumpWidget(newWidget);
+
+          // Expect our new onDidChange to run
+          expect(currentState, 'S');
+        },
+      );
+      testWidgets(
+        'onWillChange works as expected',
+            (WidgetTester tester) async {
+          String currentState;
+          final store = Store<String>(
+            identityReducer,
+            initialState: 'I',
+          );
+          Widget widget([void Function(String viewModel) onWillChange]) {
+            return StoreProvider<String>(
+              store: store,
+              child: StoreConnector<String, String>(
+                converter: selector,
+                onWillChange: onWillChange,
+                onInit: (store) => store.dispatch('A'),
+                builder: (context, vm) {
+                  return Container();
+                },
+              ),
+            );
+          }
+
+          // Build the widget with the initial state
+          await tester.pumpWidget(widget());
+
+          // No onWillChange function to run, so currentState should be null
+          expect(currentState, isNull);
+
+          // Build the widget with a new onWillChange
+          final newWidget = widget((_) => currentState = 'S');
+          await tester.pumpWidget(newWidget);
+
+          // Dispatch a new value, which should cause onWillChange to run
+          store.dispatch('B');
+
+          // Run pumpWidget, which should flush the after build (didChange)
+          // callbacks
+          await tester.pumpWidget(newWidget);
+
+          // Expect our new onWillChange to run
+          expect(currentState, 'S');
+        },
+      );
     });
   });
 


### PR DESCRIPTION
  - Always recalculate the latest value when the Widget is rebuilt
  - Handle all property updates gracefully: `onDidChange`, `onWillChange`, `distinct`, etc.
  - Add tests for these conditions