### PR TITLE
Add previous ViewModel to onWillChange

### DIFF
--- a/lib/flutter_redux.dart
+++ b/lib/flutter_redux.dart
@@ -144,9 +144,14 @@ typedef IgnoreChangeTest<S> = bool Function(S state);
 /// This function is passed the `ViewModel`, and if `distinct` is `true`,
 /// it will only be called if the `ViewModel` changes.
 ///
-/// This can be useful for imperative calls to things like Navigator,
-/// TabController, etc
-typedef OnWillChangeCallback<ViewModel> = void Function(ViewModel viewModel);
+/// This is useful for making calls to other classes, such as a
+/// `Navigator` or `TabController`, in response to state changes.
+/// It can also be used to trigger an action based on the previous
+/// state.
+typedef OnWillChangeCallback<ViewModel> = void Function(
+  ViewModel previousViewModel,
+  ViewModel newViewModel,
+);
 
 /// A function that will be run on State change, after the build method.
 ///
@@ -237,7 +242,8 @@ class StoreConnector<S, ViewModel> extends StatelessWidget {
   /// it will only be called if the `ViewModel` changes.
   ///
   /// This can be useful for imperative calls to things like Navigator,
-  /// TabController, etc
+  /// TabController, etc. This can also be useful for triggering actions
+  /// based on the previous state.
   final OnWillChangeCallback<ViewModel> onWillChange;
 
   /// A function that will be run on State change, after the Widget is built.
@@ -337,7 +343,8 @@ class StoreBuilder<S> extends StatelessWidget {
   /// A function that will be run on State change, before the Widget is built.
   ///
   /// This can be useful for imperative calls to things like Navigator,
-  /// TabController, etc
+  /// TabController, etc. This can also be useful for triggering actions
+  /// based on the previous state.
   final OnWillChangeCallback<Store<S>> onWillChange;
 
   /// A function that will be run on State change, after the Widget is built.
@@ -509,11 +516,11 @@ class _StoreStreamListenerState<S, ViewModel>
   }
 
   void _handleChange(ViewModel vm, EventSink<ViewModel> sink) {
-    latestValue = vm;
-
     if (widget.onWillChange != null) {
-      widget.onWillChange(latestValue);
+      widget.onWillChange(latestValue, vm);
     }
+
+    latestValue = vm;
 
     if (widget.onDidChange != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/test/flutter_redux_test.dart
+++ b/test/flutter_redux_test.dart
@@ -341,7 +341,7 @@ void main() {
       Widget widget() => StoreProvider<String>(
             store: store,
             child: StoreConnector<String, String>(
-              onWillChange: (_) => states.add(BuildState.before),
+              onWillChange: (_, __) => states.add(BuildState.before),
               converter: (store) => store.state,
               builder: (context, latest) {
                 states.add(BuildState.during);
@@ -578,13 +578,15 @@ void main() {
       );
       testWidgets(
         'onWillChange works as expected',
-            (WidgetTester tester) async {
+        (WidgetTester tester) async {
           String currentState;
           final store = Store<String>(
             identityReducer,
             initialState: 'I',
           );
-          Widget widget([void Function(String viewModel) onWillChange]) {
+          Widget widget([
+            void Function(String prev, String current) onWillChange,
+          ]) {
             return StoreProvider<String>(
               store: store,
               child: StoreConnector<String, String>(
@@ -605,7 +607,7 @@ void main() {
           expect(currentState, isNull);
 
           // Build the widget with a new onWillChange
-          final newWidget = widget((_) => currentState = 'S');
+          final newWidget = widget((_, __) => currentState = 'S');
           await tester.pumpWidget(newWidget);
 
           // Dispatch a new value, which should cause onWillChange to run
@@ -837,10 +839,14 @@ String identityReducer(String state, dynamic action) {
 
 class CallCounter<S> {
   final List<S> states = [];
+  final List<S> states2 = [];
 
   int get callCount => states.length;
 
-  void call(S state) => states.add(state);
+  void call(S s1, [S s2]) {
+    states.add(s1);
+    states2.add(s2);
+  }
 }
 
 enum BuildState { before, during, after }


### PR DESCRIPTION
Provides both the previous and new viewmodel to the `onWillChange` callbacks. 

Changes `onWillChange: (vm) => doSomething(vm)` to `onWillChange: (prev, next) => doSomething(prev, next)`;