### PR TITLE
Error handling converters

### DIFF
--- a/lib/flutter_redux.dart
+++ b/lib/flutter_redux.dart
@@ -434,13 +434,14 @@ class _StoreStreamListenerState<S, ViewModel>
       widget.onInit(widget.store);
     }
 
+    _computeLatestValue();
+
     if (widget.onInitialBuild != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         widget.onInitialBuild(_latestValue);
       });
     }
 
-    _computeLatestValue();
     _createStream();
 
     super.initState();
@@ -482,16 +483,17 @@ class _StoreStreamListenerState<S, ViewModel>
         ? StreamBuilder<ViewModel>(
             stream: _stream,
             builder: (context, snapshot) {
-              if (_latestError != null) {
-                throw _latestError;
-              }
+              if (_latestError != null) throw _latestError;
+
               return widget.builder(
                 context,
                 _latestValue,
               );
             },
           )
-        : widget.builder(context, _latestValue);
+        : _latestError != null
+            ? throw _latestError
+            : widget.builder(context, _latestValue);
   }
 
   ViewModel _mapConverter(S state) {
@@ -553,6 +555,7 @@ class _StoreStreamListenerState<S, ViewModel>
   ) {
     _latestValue = null;
     _latestError = ConverterError(error, stackTrace);
+    sink.addError(error, stackTrace);
   }
 }
 

--- a/lib/flutter_redux.dart
+++ b/lib/flutter_redux.dart
@@ -426,7 +426,7 @@ class _StoreStreamListenerState<S, ViewModel>
     extends State<_StoreStreamListener<S, ViewModel>> {
   Stream<ViewModel> _stream;
   ViewModel _latestValue;
-  Object _latestError;
+  ConverterError _latestError;
 
   @override
   void initState() {
@@ -587,7 +587,10 @@ https://github.com/brianegan/flutter_redux/issues/new
 
 /// If the StoreConnector throws an error,
 class ConverterError extends Error {
+  /// The error thrown while running the [StoreConnector.converter] function
   final Object error;
+
+  /// The stacktrace that accompanies the [error]
   final StackTrace stackTrace;
 
   /// Creates a ConverterError with the relevant error and stacktrace

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,4 +18,3 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: 4.1.1
-

--- a/test/flutter_redux_test.dart
+++ b/test/flutter_redux_test.dart
@@ -102,6 +102,26 @@ void main() {
       expect(find.text('I'), findsOneWidget);
     });
 
+    testWidgets('converter errors are thrown by the Widget',
+        (WidgetTester tester) async {
+      final widget = StoreProvider<String>(
+        store: Store<String>(identityReducer, initialState: 'I'),
+        child: StoreConnector<String, String>(
+          converter: (_) => throw StateError('A'),
+          builder: (context, latest) {
+            return Text(
+              latest,
+              textDirection: TextDirection.ltr,
+            );
+          },
+        ),
+      );
+
+      await tester.pumpWidget(widget);
+
+      expect(tester.takeException(), isInstanceOf<ConverterError>());
+    });
+
     testWidgets('builds the latest state of the store after a change event',
         (WidgetTester tester) async {
       final store = Store<String>(


### PR DESCRIPTION
Errors in converters are, at the moment, hard to spot. This PR changes that and makes them extremely explicit! Any time an error occurs in a converter, a `ConverterError` will be thrown with the underlying error and stacktrace. 

On device, it will look like a normal "Big Red Error"

![Screenshot_1582119968](https://user-images.githubusercontent.com/126604/74940431-b230fc80-53f1-11ea-95ff-e2dde1c00938.png)

In your terminal, it will display the full stacktrace so you can click on the offending line to jump right to it:

<img width="1027" alt="Screen Shot 2020-02-19 at 2 46 46 PM" src="https://user-images.githubusercontent.com/126604/74940524-d7be0600-53f1-11ea-8f25-3608b19067f2.png">
