### PR TITLE
Replace deprecated methods

### DIFF
--- a/lib/flutter_redux.dart
+++ b/lib/flutter_redux.dart
@@ -72,14 +72,16 @@ class StoreProvider<S> extends InheritedWidget {
   /// }
   /// ```
   static Store<S> of<S>(BuildContext context, {bool listen = true}) {
-    final type = _typeOf<StoreProvider<S>>();
     final provider = (listen
-        ? context.inheritFromWidgetOfExactType(type)
+        ? context.dependOnInheritedWidgetOfExactType<StoreProvider<S>>()
         : context
-            .ancestorInheritedElementForWidgetOfExactType(type)
+            .getElementForInheritedWidgetOfExactType<StoreProvider<S>>()
             ?.widget) as StoreProvider<S>;
 
-    if (provider == null) throw StoreProviderError(type);
+    if (provider == null) {
+      final type = _typeOf<StoreProvider<S>>();
+      throw StoreProviderError(type);
+    }
 
     return provider._store;
   }


### PR DESCRIPTION
The changed methods became deprecated on the Stable channel recently, so I replaced them with the recommended methods that use Generics.

I moved `_typeOf` call to the error handling part as it is only used there. Maybe we could consider getting rid of it? Something to consider on another PR.