### PR TITLE
feature: hooks

### DIFF
--- a/example/github_search/ios/Runner/GeneratedPluginRegistrant.h
+++ b/example/github_search/ios/Runner/GeneratedPluginRegistrant.h
@@ -7,8 +7,11 @@
 
 #import <Flutter/Flutter.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface GeneratedPluginRegistrant : NSObject
 + (void)registerWithRegistry:(NSObject<FlutterPluginRegistry>*)registry;
 @end
 
+NS_ASSUME_NONNULL_END
 #endif /* GeneratedPluginRegistrant_h */

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,10 +12,10 @@ dependencies:
   redux: ">=4.0.0 <5.0.0"
   flutter:
     sdk: flutter
+  flutter_hooks: ^0.12.0
 
 dev_dependencies:
   pedantic: 1.8.0+1
   flutter_test:
     sdk: flutter
   mockito: 4.1.1
-


### PR DESCRIPTION
I added three simple hooks to work with the store, `useStore`, `useSelector` and `useDispatch`, just like in `react`. Since I had to add a dependency to `flutter_hooks` this may be better off being its own lib but I just wanted to know whether you'd be interested in having this as a part of `flutter_redux`. In any case, I plan to add at least an example and some documentation in the readme in case you would consider merging this.