### PR TITLE
GitHub Search Example: Updated dependencies and code to support newer version of rxdart

### DIFF
--- a/example/github_search/lib/redux.dart
+++ b/example/github_search/lib/redux.dart
@@ -123,12 +123,12 @@ class SearchEpic implements EpicClass<SearchState> {
 
   @override
   Stream<dynamic> call(Stream<dynamic> actions, EpicStore<SearchState> store) {
-    return Observable(actions)
-        // Narrow down to SearchAction actions
-        .ofType(TypeToken<SearchAction>())
-        // Don't start searching until the user pauses for 250ms
-        .debounce(Duration(milliseconds: 250))
-        // Cancel the previous search and start a one with switchMap
+    return actions
+    // Narrow down to SearchAction actions
+        .whereType<SearchAction>()
+    // Don't start searching until the user pauses for 250ms
+        .debounce((_) => TimerStream(true, Duration(milliseconds: 250)))
+    // Cancel the previous search and start a one with switchMap
         .switchMap((action) => _search(action.term));
   }
 

--- a/example/github_search/pubspec.yaml
+++ b/example/github_search/pubspec.yaml
@@ -1,14 +1,17 @@
 name: github_search
 description: A new flutter project.
 
+environment:
+  sdk: ">=2.7.0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter
-  flutter_redux: 0.5.0
-  async: 2.0.8
-  redux_epics: 0.10.3
-  rxdart: ^0.20.0
-  transparent_image:
+  flutter_redux: ^0.6.0
+  async: ^2.4.2
+  redux_epics: ^0.14.0
+  rxdart: ^0.24.1
+  transparent_image: ^1.0.0
 
 dev_dependencies:
   pedantic: ^1.8.0+1


### PR DESCRIPTION
`rxdart` have moved away from `Observables` and now uses `Streams` [Upgrading from RxDart 0.22.x to 0.23.x](https://pub.dev/packages/rxdart#upgrading-from-rxdart-022x-to-023x)