### PR TITLE
Properly expose errors from OnWillChange / onDidChange

### DIFF
--- a/lib/flutter_redux.dart
+++ b/lib/flutter_redux.dart
@@ -471,7 +471,7 @@ class _StoreStreamListenerState<S, ViewModel>
     _computeLatestValue();
 
     if (widget.onInitialBuild != null) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
+      WidgetsBinding.instance?.addPostFrameCallback((_) {
         widget.onInitialBuild!(_requireLatestValue);
       });
     }
@@ -574,7 +574,7 @@ class _StoreStreamListenerState<S, ViewModel>
     _latestValue = vm;
 
     if (widget.onDidChange != null) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
+      WidgetsBinding.instance?.addPostFrameCallback((_) {
         if (mounted) {
           widget.onDidChange!(previousValue, _requireLatestValue);
         }

--- a/test/flutter_redux_test.dart
+++ b/test/flutter_redux_test.dart
@@ -739,6 +739,34 @@ void main() {
           expect(currentState, 'S');
         },
       );
+
+      testWidgets('onDidChange errors are thrown by the Widget',
+          (WidgetTester tester) async {
+        final store = Store<String>(identityReducer, initialState: 'I');
+        final widget = StoreProvider<String>(
+          store: store,
+          child: StoreConnector<String, String>(
+            converter: (store) => store.state,
+            onDidChange: (_, __) => throw StateError('OnDidChange Error'),
+            builder: (context, latest) {
+              return Text(
+                latest,
+                textDirection: TextDirection.ltr,
+              );
+            },
+          ),
+        );
+
+        await tester.pumpWidget(widget);
+
+        // Dispatch a new value, which should cause onWillChange to run
+        store.dispatch('B');
+
+        // Pump the widget tree display any errors
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isInstanceOf<StateError>());
+      });
       testWidgets(
         'onWillChange works as expected',
         (WidgetTester tester) async {
@@ -784,6 +812,35 @@ void main() {
           expect(currentState, 'S');
         },
       );
+
+      
+      testWidgets('onWillChange errors are thrown by the Widget',
+          (WidgetTester tester) async {
+        final store = Store<String>(identityReducer, initialState: 'I');
+        final widget = StoreProvider<String>(
+          store: store,
+          child: StoreConnector<String, String>(
+            converter: (store) => store.state,
+            onWillChange: (_, __) => throw StateError('onWillChange Error'),
+            builder: (context, latest) {
+              return Text(
+                latest,
+                textDirection: TextDirection.ltr,
+              );
+            },
+          ),
+        );
+
+        await tester.pumpWidget(widget);
+
+        // Dispatch a new value, which should cause onWillChange to run
+        store.dispatch('B');
+
+        // Pump the widget tree display any errors
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isInstanceOf<StateError>());
+      });
     });
   });
 


### PR DESCRIPTION
@atoka93

Errors thrown in the onDidChange & onWillChange callbacks now make the widget go Bright Red, displaying the error. This works the same way as errors thrown in the `converter` function.